### PR TITLE
Fix for broken footer and italic font

### DIFF
--- a/static/galapagos.css
+++ b/static/galapagos.css
@@ -6,7 +6,7 @@
 @import url('https://fontlibrary.org/face/hk-grotesk');
 
 html, body {
-	font-family: 'HK Grotesk Regular', sans-serif;
+	font-family: 'HKGroteskRegular', sans-serif;
 	font-weight: normal;
 }
 

--- a/static/galapagos.css
+++ b/static/galapagos.css
@@ -81,10 +81,11 @@ body > footer {
     -webkit-box-shadow: 0 0px 10px 0 #777;
     box-shadow: 0 0px 10px 0 #777;
     height: 3em;
+    font-size: 11pt;
     line-height: 2em;
     margin: 0;
     padding: 0.5em 0;
-    position: absolute;
+    position: fixed;
     left: 0;
     bottom: 0;
     width: 100%;

--- a/static/galapagos.css
+++ b/static/galapagos.css
@@ -6,7 +6,7 @@
 @import url('https://fontlibrary.org/face/hk-grotesk');
 
 html, body {
-	font-family: 'HK Grotesk', sans-serif;
+	font-family: 'HK Grotesk Regular', sans-serif;
 	font-weight: normal;
 }
 


### PR DESCRIPTION
This should hopefully fix the footer to the bottom of the screen. 

Tested with Firefox 50.0.1, Chromium 55.0