### PR TITLE
[RFC] Initial papercut fixes for mobile

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -6,6 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link href="/static/kube.css" type="text/css" rel="stylesheet">
 		<link href="/static/galapagos.css" type="text/css" rel="stylesheet">
+		<link href="/static/mobile.css" type="text/css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -30,11 +31,11 @@
 
 		<footer>
 			<div class="row">
-			<div class="col col-6">
-				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
-			</div>
-			<div class="col col-6">
+			<div class="col col-6" id="left">
 				<!-- List of links goes here. -->
+			</div>
+			<div class="col col-6" id="right">
+				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
 			</div>
 			</div>
 		</footer>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -6,6 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link href="/static/kube.css" type="text/css" rel="stylesheet">
 		<link href="/static/galapagos.css" type="text/css" rel="stylesheet">
+		<link href="/static/mobile.css" type="text/css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -30,11 +31,11 @@
 
 		<footer>
 			<div class="row">
-			<div class="col col-6">
-				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
-			</div>
-			<div class="col col-6">
+			<div class="col col-6" id="left">
 				<!-- List of links goes here. -->
+			</div>
+			<div class="col col-6" id="right">
+				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
 			</div>
 			</div>
 		</footer>

--- a/download/index.html
+++ b/download/index.html
@@ -6,6 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link href="/static/kube.css" type="text/css" rel="stylesheet">
 		<link href="/static/galapagos.css" type="text/css" rel="stylesheet">
+		<link href="/static/mobile.css" type="text/css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -30,11 +31,11 @@
 
 		<footer>
 			<div class="row">
-			<div class="col col-6">
-				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
-			</div>
-			<div class="col col-6">
+			<div class="col col-6" id="left">
 				<!-- List of links goes here. -->
+			</div>
+			<div class="col col-6" id="right">
+				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
 			</div>
 			</div>
 		</footer>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
 		<title>Galapagos Linux welcomes you</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<link href="static/kube.css" type="text/css" rel="stylesheet">
-		<link href="static/galapagos.css" type="text/css" rel="stylesheet">
+		<link href="/static/kube.css" type="text/css" rel="stylesheet">
+		<link href="/static/galapagos.css" type="text/css" rel="stylesheet">
+		<link href="/static/mobile.css" type="text/css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -29,7 +30,7 @@
 			<br>
 
 			<div class="row hero equal">
-				<div class="col col-6">
+				<div class="col col-6" id="first">
 					<div class="inner">
 					<p><span class="lead">Galapagos is the friendly source-based Linux distribution.</span>
 					Built out of the long history of the venerable <a href="https://gentoo.org/">Gentoo Linux</a> distribution, Galapagos has three defining goals.</p>
@@ -41,7 +42,7 @@
 					</ol>
 					</div>
 				</div>
-				<div class="col col-6">
+				<div class="col col-6" id="second">
 					<div class="inner">
 					<h3>Interested?</h3>
 					<p>Galapagos Linux is available for Intel x86, PowerPC, ARM, MIPS, SPARC, and other architectures.  And it's entirely free and open source.  Try it now and see how Galapagos is making Linux fun again!</p>
@@ -67,11 +68,11 @@
 
 		<footer>
 			<div class="row">
-			<div class="col col-6">
-				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
-			</div>
-			<div class="col col-6">
+			<div class="col col-6" id="left">
 				<!-- List of links goes here. -->
+			</div>
+			<div class="col col-6" id="right">
+				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
 			</div>
 			</div>
 		</footer>

--- a/static/galapagos.css
+++ b/static/galapagos.css
@@ -52,6 +52,21 @@ section#content {
     padding: 1em;
 }
 
+/* Add margin between main content hero boxes since they will be on top
+ * of one another in some situations */
+.hero > .col {
+    margin-bottom: 2em;
+}
+
+/* Add margin between download / doc buttons since they will be on top
+ * of one another in some situations */
+.hero > .col#second a.button {
+    margin-bottom: 1em;
+    display: inline-flex;
+    flex-direction: column;
+    padding: 14px 2em;
+}
+
 .hero > .col > .inner {
     background: #ddd;
     border-radius: 1em;
@@ -83,7 +98,7 @@ body > footer {
     height: 3em;
     line-height: 2em;
     margin: 0;
-    padding: 0.5em 0;
+    padding: 0.5em 0.5em;
     position: fixed;
     left: 0;
     bottom: 0;

--- a/static/galapagos.css
+++ b/static/galapagos.css
@@ -81,7 +81,6 @@ body > footer {
     -webkit-box-shadow: 0 0px 10px 0 #777;
     box-shadow: 0 0px 10px 0 #777;
     height: 3em;
-    font-size: 11pt;
     line-height: 2em;
     margin: 0;
     padding: 0.5em 0;
@@ -91,3 +90,19 @@ body > footer {
     width: 100%;
 }
 
+body > footer > .row {
+    flex-wrap: nowrap;
+}
+
+body > footer > .row > .col-6#left {
+    width: auto;
+    max-width: none;
+    flex-basis: auto;
+}
+
+body > footer > .row > .col-6#right {
+    width: auto;
+    max-width: none;
+    flex-basis: auto;
+    text-align: right;
+}

--- a/static/mobile.css
+++ b/static/mobile.css
@@ -1,4 +1,4 @@
-@media only screen and (max-device-width: 750px) {
+@media only screen and (max-device-width: 768px) {
     /* Make header links visible */
     body > header > .row {
         height: auto;
@@ -7,18 +7,6 @@
     body > header > .row > .hide-on-print {
         background-color: #AD6A91;
         border-radius: 4px;
-    }
-
-    /* Add margin between main content hero boxes since they will be on top
-     * of one another */
-    .hero > .col#first {
-        margin-bottom: 2em;
-    }
-
-    /* Add margin between download / doc buttons since they will be on top
-     * of one another */
-    .hero > .col#second a.primary {
-        margin-bottom: 1em;
     }
 
     /* Anchor footer to bottom, decrease font size
@@ -34,14 +22,14 @@
     }
 
     body > #content {
-        padding-bottom: 5em;
+        padding-bottom: 8em;
         margin-bottom: 0;
     }
 
     body > footer {
         position: absolute;
         bottom: 0;
-        height: 5em;
+        height: auto;
         font-size: 10pt;
     }
 

--- a/static/mobile.css
+++ b/static/mobile.css
@@ -21,10 +21,27 @@
         margin-bottom: 1em;
     }
 
-    /* Anchor footer to bottom, decrease font size */
+    /* Anchor footer to bottom, decrease font size
+     * NB: padding-bottom and height will need to be adjusted in the future
+     *     if more content is added to the footer! */
+    html {
+        position: relative;
+    }
+
+    body, html {
+        min-height: 100%;
+        margin: 0;
+    }
+
+    body > #content {
+        padding-bottom: 5em;
+        margin-bottom: 0;
+    }
+
     body > footer {
-        position: static;
-        height: auto;
+        position: absolute;
+        bottom: 0;
+        height: 5em;
         font-size: 10pt;
     }
 

--- a/static/mobile.css
+++ b/static/mobile.css
@@ -1,0 +1,39 @@
+@media only screen and (max-device-width: 750px) {
+    /* Make header links visible */
+    body > header > .row {
+        height: auto;
+    }
+
+    body > header > .row > .hide-on-print {
+        background-color: #AD6A91;
+        border-radius: 4px;
+    }
+
+    /* Add margin between main content hero boxes since they will be on top
+     * of one another */
+    .hero > .col#first {
+        margin-bottom: 2em;
+    }
+
+    /* Add margin between download / doc buttons since they will be on top
+     * of one another */
+    .hero > .col#second a.primary {
+        margin-bottom: 1em;
+    }
+
+    /* Anchor footer to bottom, decrease font size */
+    body > footer {
+        position: static;
+        height: auto;
+        font-size: 10pt;
+    }
+
+    body > footer > .row {
+        flex-wrap: wrap;
+    }
+
+    /* Since footer will not be one line, restore left-aligned text */
+    body > footer > .row > .col-6#right {
+        text-align: left;
+    }
+}

--- a/template
+++ b/template
@@ -6,6 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link href="/static/kube.css" type="text/css" rel="stylesheet">
 		<link href="/static/galapagos.css" type="text/css" rel="stylesheet">
+		<link href="/static/mobile.css" type="text/css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -30,11 +31,11 @@
 
 		<footer>
 			<div class="row">
-			<div class="col col-6">
-				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
-			</div>
-			<div class="col col-6">
+			<div class="col col-6" id="left">
 				<!-- List of links goes here. -->
+			</div>
+			<div class="col col-6" id="right">
+				Copyright &copy; 2016 Galapagos Linux.  All rights reserved.  Web site content is licensed under CC-BY-SA-3.0.
 			</div>
 			</div>
 		</footer>


### PR DESCRIPTION
**NB:** A live preview of these changes is available at [g7sweb.uwtb.net](http://g7sweb.uwtb.net)

Any additional recommended changes are requested.

### Description (from commit message)
Changes for mobile:
* The header links are now visible
* The footer is anchored to the bottom of the page with smaller
  font-size
* Some margins were added to various boxes that end up stacking on
  mobile

Changes for desktop:
* The issue where text was being cut-off should be fixed (for real this
  time!)

Global changes:
* The copyright notice was moved to the right-side of the footer in
  anticipation of links being added to the left side so that the links
  will appear before the copyright notice on mobile
* Update template with the above change and add mobile.css